### PR TITLE
fix error reporting by passing file to processCode

### DIFF
--- a/src/ComposerBackslasher/Backslasher.php
+++ b/src/ComposerBackslasher/Backslasher.php
@@ -44,7 +44,7 @@ class Backslasher
 			}
 
 			$input = file_get_contents((string) $entry);
-			$output = $this->processCode($input);
+			$output = $this->processCode((string) $entry, $input);
 			if ($output !== $input) {
 				file_put_contents((string) $entry, $output);
 			}
@@ -57,7 +57,7 @@ class Backslasher
 	/**
 	 * @return string
 	 */
-	public function processCode($code)
+	public function processCode($file, $code)
 	{
 		try {
 			$nodes = $this->parser->parse($code);

--- a/tests/Backslasher.processCode.phpt
+++ b/tests/Backslasher.processCode.phpt
@@ -10,6 +10,6 @@ $backslasher = new DG\ComposerBackslasher\Backslasher($io);
 for ($i = 1; $i <= 4; $i++) {
 	Assert::matchFile(
 		__DIR__ . "/fixtures/test{$i}.expected.php",
-		$backslasher->processCode(file_get_contents(__DIR__ . "/fixtures/test{$i}.php"))
+		$backslasher->processCode(__DIR__ . "/fixtures/test{$i}.php", file_get_contents(__DIR__ . "/fixtures/test{$i}.php"))
 	);
 }


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

Hello, the `processCode` method is using `$file` variable for printing parse errors, but that variable did not exist here. This throws `ErrorException (Undefined variable: file)` which hides the real errors and stops the process.
